### PR TITLE
Add lando script for first time build

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -8,6 +8,9 @@ services:
     type: node
     globals:
       gulp-cli: "latest"
+  appserver:
+    run:
+      - /app/scripts/init.sh
 
 events:
   post-start:

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ ! -z $LANDO_MOUNT ]; then
+  cd $LANDO_MOUNT
+
+  # Copy asset files.
+  if [ ! -d "web/sites/default/files" ]; then
+    echo "Creating Drupal default files directory"
+    chmod 755 web/sites/default
+    mkdir web/sites/default/files
+    chmod 777 web/sites/default/files
+    chmod 555 web/sites/default
+  fi
+  cp -r assets/imgs/. web/sites/default/files/.
+
+  # Check if the DB is empty before importing the gzipped backup.
+  DRUPAL_NOT_INSTALLED=`drush status bootstrap | grep -q Successful`
+  if [ DRUPAL_NOT_INSTALLED ]; then
+    echo "Importing Drupal database"
+    gunzip -c drupal8.export.gz | drush sqlc
+  fi
+fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -13,8 +13,9 @@ if [ ! -z $LANDO_MOUNT ]; then
   cp -r assets/imgs/. web/sites/default/files/.
 
   # Check if the DB is empty before importing the gzipped backup.
-  DRUPAL_NOT_INSTALLED=`drush status bootstrap | grep -q Successful`
-  if [ DRUPAL_NOT_INSTALLED ]; then
+  drush status bootstrap | grep Successful > /dev/null
+  IMPORT_DATABASE=$?
+  if [ $IMPORT_DATABASE -eq 1 ]; then
     echo "Importing Drupal database"
     gunzip -c drupal8.export.gz | drush sqlc
   fi


### PR DESCRIPTION
Added a new script file to handle basic build processes. This
should ensure that the steps are only run the first time the
lando environment is setup and should reduce import time.